### PR TITLE
Druid user permissions apply in the console

### DIFF
--- a/docs/design/processes.md
+++ b/docs/design/processes.md
@@ -78,7 +78,7 @@ caller. End users typically query Brokers rather than querying Historicals or Mi
 Overlords, and Coordinators. They are optional since you can also simply contact the Druid Brokers, Overlords, and
 Coordinators directly.
 
-The Router also runs the [Druid Console](../operations/management-uis.html#druid-console), a management UI for datasources, segments, tasks, data processes (Historicals and MiddleManagers), and coordinator dynamic configuration. The user can also run SQL and native Druid queries within the console.
+The Router also runs the [Druid Console](../operations/druid-console.md), a management UI for datasources, segments, tasks, data processes (Historicals and MiddleManagers), and coordinator dynamic configuration. The user can also run SQL and native Druid queries within the console.
 
 ### Data server
 

--- a/docs/design/router.md
+++ b/docs/design/router.md
@@ -24,13 +24,13 @@ title: "Router Process"
 
 
 > The Router is an optional and [experimental](../development/experimental.md) feature due to the fact that its recommended place in the Druid cluster architecture is still evolving.
-> However, it has been battle-tested in production, and it hosts the powerful [Druid Console](../operations/management-uis.html#druid-console), so you should feel safe deploying it.
+> However, it has been battle-tested in production, and it hosts the powerful [Druid Console](../operations/druid-console.md), so you should feel safe deploying it.
 
 The Apache Druid Router process can be used to route queries to different Broker processes. By default, the broker routes queries based on how [Rules](../operations/rule-configuration.md) are set up. For example, if 1 month of recent data is loaded into a `hot` cluster, queries that fall within the recent month can be routed to a dedicated set of brokers. Queries outside this range are routed to another set of brokers. This set up provides query isolation such that queries for more important data are not impacted by queries for less important data.
 
 For query routing purposes, you should only ever need the Router process if you have a Druid cluster well into the terabyte range.
 
-In addition to query routing, the Router also runs the [Druid Console](../operations/management-uis.html#druid-console), a management UI for datasources, segments, tasks, data processes (Historicals and MiddleManagers), and coordinator dynamic configuration. The user can also run SQL and native Druid queries within the console.
+In addition to query routing, the Router also runs the [Druid Console](../operations/druid-console.md), a management UI for datasources, segments, tasks, data processes (Historicals and MiddleManagers), and coordinator dynamic configuration. The user can also run SQL and native Druid queries within the console.
 
 ### Configuration
 

--- a/docs/operations/druid-console.md
+++ b/docs/operations/druid-console.md
@@ -37,8 +37,7 @@ The Druid console can be accessed at:
 http://<ROUTER_IP>:<ROUTER_PORT>
 ```
 
-> It is important to note that any Druid console user will have, effectively, the same machine permission as 
-the user under which Druid runs. One way these permissions are manifested, for example, is in the file browser dialog. The dialog
+> It is important to note that any Druid console user will have, effectively, the same file permissions as the user under which Druid runs. One way these permissions are surfaced is in the file browser dialog. The dialog
 will show console users the files that the underlying user has permissions to. In general, avoid running Druid as 
 root user. Consider creating a dedicated user account for running Druid.
 

--- a/docs/operations/druid-console.md
+++ b/docs/operations/druid-console.md
@@ -37,10 +37,10 @@ The Druid console can be accessed at:
 http://<ROUTER_IP>:<ROUTER_PORT>
 ```
 
-> Note that any Druid console user will have, effectively, the same permissions as 
-the user under which Druid runs. This is important to consider, since the file browser UI will show console users the files that 
-the underlying user can  access. In general, avoid running Druid as root user. Consider creating a dedicated user account 
-for running Druid.
+> It is important to note that any Druid console user will have, effectively, the same machine permission as 
+the user under which Druid runs. One way these permissions are manifested, for example, is in the file browser dialog. The dialog
+will show console users the files that the underlying user has permissions to. In general, avoid running Druid as 
+root user. Consider creating a dedicated user account for running Druid.
 
 Below is a description of the high-level features and functionality of the Druid Console
 

--- a/docs/operations/druid-console.md
+++ b/docs/operations/druid-console.md
@@ -22,19 +22,25 @@ title: "Web console"
   ~ under the License.
   -->
 
+Druid include a console for managing datasources, segments, tasks, data processes (Historicals and MiddleManagers), and coordinator dynamic configuration. Users can also run SQL and native Druid queries in the console.
 
 The Druid Console is hosted by the [Router](../design/router.md) process.
 
-In addition, the following cluster settings must be enabled:
+The following cluster settings must be enabled, as they are by default:
 
 - the Router's [management proxy](../design/router.html#enabling-the-management-proxy) must be enabled.
 - the Broker processes in the cluster must have [Druid SQL](../querying/sql.md) enabled.
 
-After enabling Druid SQL on the Brokers and deploying a Router with the management proxy enabled, the Druid console can be accessed at:
+The Druid console can be accessed at:
 
 ```
 http://<ROUTER_IP>:<ROUTER_PORT>
 ```
+
+> Note that any Druid console user will have, effectively, the same permissions as 
+the user under which Druid runs. This is important to consider, since the file browser UI will show console users the files that 
+the underlying user can  access. In general, avoid running Druid as root user. Consider creating a dedicated user account 
+for running Druid.
 
 Below is a description of the high-level features and functionality of the Druid Console
 

--- a/docs/operations/management-uis.md
+++ b/docs/operations/management-uis.md
@@ -1,6 +1,6 @@
 ---
 id: management-uis
-title: "Management UIs"
+title: "Legacy Management UIs"
 ---
 
 <!--
@@ -23,28 +23,13 @@ title: "Management UIs"
   -->
 
 
-## Druid console
+## Legacy consoles
 
 Druid provides a console for managing datasources, segments, tasks, data processes (Historicals and MiddleManagers), and coordinator dynamic configuration. The user can also run SQL and native Druid queries within the console.
 
-The Druid Console is hosted by the [Router](../design/router.md) process. We recommend running the Router process on your [Query server](../design/processes.md).
-
-In addition, the following cluster settings must be enabled:
-
-- the Router's [management proxy](../design/router.html#enabling-the-management-proxy) must be enabled.
-- the Broker processes in the cluster must have [Druid SQL](../querying/sql.md) enabled.
-
-After enabling Druid SQL on the Brokers and deploying a Router with the management proxy enabled, the Druid console can be accessed at:
-
-```
-http://<ROUTER_IP>:<ROUTER_PORT>
-```
+For more information on the Druid Console, have a look at the [Druid Console overview](./druid-console.md)
 
 The Druid Console contains all of the functionality provided by the older consoles described below, which are still available if needed. The legacy consoles may be replaced by the Druid Console in the future.
-
-For more information on the features of the Druid Console have a look at the [Druid Console overview](./druid-console.md)
-
-## Legacy consoles
 
 These older consoles provide a subset of the functionality of the Druid Console. We recommend using the Druid Console if possible.
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -54,10 +54,10 @@ The software requirements for the installation machine are:
 `DRUID_JAVA_HOME` if there is more than one instance of Java. To verify Java requirements for your environment, run the 
 `bin/verify-java` script.
 
-When installing a production Druid instance, be sure to consider the user under which Druid will run. This is important
-because any Druid console user will effectively have the same permissions as that user. So, for example, in the file 
-browser UI, console users will have the same file access permissions as the Druid user. In general, do not 
-install or run Druid as root. Consider creating a dedicated user under which Druid will run.   
+Before installing a production Druid instance, be sure to consider the user account on the operating system under 
+which Druid will run. This is important because any Druid console user will have, effectively, the same permissions as 
+that user. So, for example, the file browser UI will show console users the files that the underlying user can 
+access. In general, avoid running Druid as root user. Consider creating a dedicated user account for running Druid.   
 
 ## Step 1. Install Druid
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -54,6 +54,10 @@ The software requirements for the installation machine are:
 `DRUID_JAVA_HOME` if there is more than one instance of Java. To verify Java requirements for your environment, run the 
 `bin/verify-java` script.
 
+When installing a production Druid instance, be sure to consider the user under which Druid will run. This is important
+because any Druid console user will effectively have the same permissions as that user. So, for example, in the file 
+browser UI, console users will have the same file access permissions as the Druid user. In general, do not 
+install or run Druid as root. Consider creating a dedicated user under which Druid will run.   
 
 ## Step 1. Install Druid
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -334,7 +334,7 @@
         "title": "kubernetes"
       },
       "operations/management-uis": {
-        "title": "Management UIs"
+        "title": "Legacy Management UIs"
       },
       "operations/metadata-migration": {
         "title": "Metadata Migration"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -111,7 +111,8 @@
       "configuration/logging"
     ],
     "Operations": [
-      "operations/management-uis",
+      "operations/druid-console",
+      "operations/getting-started",
       "operations/basic-cluster-tuning",
       "operations/api-reference",
       "operations/high-availability",
@@ -131,10 +132,9 @@
         "type": "subcategory",
         "label": "Misc",
         "ids": [
+          "operations/management-uis",
           "operations/deep-storage-migration",
-          "operations/druid-console",
           "operations/export-metadata",
-          "operations/getting-started",
           "operations/metadata-migration",
           "operations/segment-optimization",
           "operations/use_sbt_to_build_fat_jar"


### PR DESCRIPTION
Adding a note to use care when choosing the user under which Druid runs on the machine. The permissions of that user carry over to the console as well, and are therefore indirectly given to all console users as well. 